### PR TITLE
Fix AppVeyor configuration to match current oF master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,31 +1,35 @@
 version: 1.0.{build}
-os: Visual Studio 2015 RC
 
 environment:
   global:
     APPVEYOR_OS_NAME: windows
   matrix:
   #MSYS2 Building
-    - platform: x86
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
       BUILDER: MSYS2
 
   #VisualStudio Building
-    - platform: x86
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x86
       BUILDER : VS
       BITS: 32
-    - platform: x64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      platform: x64
       BUILDER : VS
       BITS: 64
 
 configuration: Debug
 shallow_clone: true
 clone_depth: 10
+
 init:
 - set MSYS2_PATH=c:\msys64
 - set CHERE_INVOKING=1
 - if "%BUILDER%_%PLATFORM%"=="MSYS2_x86" set MSYSTEM=MINGW32
 - if "%BUILDER%_%PLATFORM%"=="MSYS2_x64" set MSYSTEM=MINGW64
-- if "%BUILDER%"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -S --needed unzip rsync"'
+- if "%BUILDER%"=="VS" set PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%PATH%
 
 install:
 - cd ..


### PR DESCRIPTION
Updated .appveyor to match oF master at 06ea4f9628732e9aa67bbf11eec42ef935f26c94. I did not add the cache related lines, since they were failing when I was testing the script with ofxPiMapper.